### PR TITLE
Fix Fortran ordering with selection, add shape and no selection tests, floating point comparison

### DIFF
--- a/compliance/test_basic_operations.py
+++ b/compliance/test_basic_operations.py
@@ -62,7 +62,7 @@ def generate_test_data(
 
 #Stacking parametrization decorators tells pytest to check every possible combination of parameters
 @pytest.mark.parametrize('order', ['C', 'F'])
-@pytest.mark.parametrize('shape, selection', [(None, None), ([100], [[10, 50, 4]]), ([20, 5], [[0, 19, 2], [1, 3, 1]])])
+@pytest.mark.parametrize('shape, selection', [(None, None), ([5, 5, 4], None), ([100], [[10, 50, 4]]), ([20, 5], [[0, 19, 2], [1, 3, 1]])])
 @pytest.mark.parametrize('dtype', ALLOWED_DTYPES)
 @pytest.mark.parametrize('operation', OPERATION_FUNCS.keys())
 def test_basic_operation(monkeypatch, operation, dtype, shape, selection, order, offset=None, size=None):

--- a/compliance/test_basic_operations.py
+++ b/compliance/test_basic_operations.py
@@ -110,7 +110,8 @@ def test_basic_operation(monkeypatch, operation, dtype, shape, selection, order,
     expected_shape = list(operation_result.shape)
     proxy_shape = json.loads(proxy_response.headers['x-activestorage-shape'])
     assert proxy_shape == expected_shape
-    assert proxy_response.content == operation_result.tobytes(order=order)
+    proxy_result = proxy_result.reshape(proxy_shape, order=order)
+    assert np.allclose(proxy_result, operation_result), f"actual:\n{proxy_result}\n!=\nexpected:\n{operation_result}"
     assert proxy_response.headers['content-length'] == str(len(operation_result.tobytes()))
 
 

--- a/compliance/test_basic_operations.py
+++ b/compliance/test_basic_operations.py
@@ -96,7 +96,7 @@ def test_basic_operation(monkeypatch, operation, dtype, shape, selection, order,
     proxy_response = requests.post(f'{PROXY_URL}/v1/{operation}/', json=request_data, auth=(AWS_ID, AWS_PASSWORD))
 
     #For debugging failed tests
-    if proxy_response != 200:
+    if proxy_response.status_code != 200:
         print(proxy_response.text)
 
     assert proxy_response.status_code == 200

--- a/compliance/test_basic_operations.py
+++ b/compliance/test_basic_operations.py
@@ -1,4 +1,5 @@
 
+import json
 import pytest
 import requests
 import numpy as np
@@ -106,7 +107,9 @@ def test_basic_operation(monkeypatch, operation, dtype, shape, selection, order,
     # Compare to expected result and make sure response headers are sensible - all comparisons should be done as strings
     print('\nProxy result:', proxy_result, '\nExpected result:', operation_result) #For debugging
     assert proxy_response.headers['x-activestorage-dtype'] == (request_data['dtype'] if operation != 'count' else 'int64')
-    assert proxy_response.headers['x-activestorage-shape'] == str(list(operation_result.shape)) if operation != 'count' else '[1]'
+    expected_shape = list(operation_result.shape)
+    proxy_shape = json.loads(proxy_response.headers['x-activestorage-shape'])
+    assert proxy_shape == expected_shape
     assert proxy_response.content == operation_result.tobytes(order=order)
     assert proxy_response.headers['content-length'] == str(len(operation_result.tobytes()))
 

--- a/compliance/utils.py
+++ b/compliance/utils.py
@@ -15,11 +15,12 @@ def ensure_test_bucket_exists():
         pass #Bucket already exists
 
 
-def upload_to_s3(s3_client, arr: np.array, filename: str, order='C') -> None:
+def upload_to_s3(s3_client, arr: np.array, filename: str) -> None:
 
     """ Upload a numpy array in binary format to an S3 storage bucket """
 
-    stream = io.BytesIO(arr.tobytes(order=order))
+    # NOTE: At this point it's a 1D array, so C/F order doesn't apply.
+    stream = io.BytesIO(arr.tobytes())
     s3_client.upload_fileobj(stream, BUCKET_NAME, filename)
 
     return


### PR DESCRIPTION
- Fix Fortran ordering with selection
- Add a test_basic_operation parameter with shape and no selection
- Fix debugging condition
- Decode returned shape header from JSON
- Use numpy.allclose when comparing arrays
