### PR TITLE
Make error compliance tests less strict

### DIFF
--- a/compliance/test_error_response.py
+++ b/compliance/test_error_response.py
@@ -62,7 +62,7 @@ def test_nonexistent_file(monkeypatch):
     #Check the response is sensible
     # Minio returns 404 but radosgw returs 500 so just check response code is something error-like
     assert response.status_code >= 400
-    assert response.headers['content-type'] == 'application/json'
+    assert response.headers.get('content-type') == 'application/json'
     # assert <something-about-informative-error-message-in-response-body?>
 
     
@@ -77,8 +77,8 @@ def test_invalid_operation(monkeypatch):
     response = make_request(op=invalid_operation)
 
     #Check the response is sensible
-    assert response.status_code == 422
-    assert response.headers['content-type'] == 'application/json'
+    assert response.status_code in (404, 422)
+    assert response.headers.get('content-type') == 'application/json'
     assert 'operation' in response.text.lower() #Check for informative error message
     
 
@@ -92,9 +92,7 @@ def test_invalid_dtype(monkeypatch):
     response = make_request(dtype=invalid_dtype)
 
     #Check the response is sensible
-    assert response.status_code == 422
-    assert 'not' in response.text.lower()
-    assert 'valid' in response.text.lower()
+    assert response.status_code in (400, 422)
     assert 'dtype' in response.text.lower()
 
 
@@ -109,7 +107,7 @@ def test_invalid_offset(monkeypatch):
     response = make_request(offset=invalid_offset)
 
     #Check the response is sensible
-    assert response.status_code == 422
+    assert response.status_code in (400, 422)
     assert 'offset' in response.text.lower()
 
 
@@ -123,7 +121,7 @@ def test_invalid_size(monkeypatch):
     response = make_request(size=invalid_size)
 
     #Check the response is sensible
-    assert response.status_code == 422
+    assert response.status_code in (400, 422)
     assert 'size' in response.text.lower()
 
 
@@ -138,7 +136,7 @@ def test_invalid_shape(monkeypatch):
     response = make_request(shape=invalid_shape)
 
     #Check the response is sensible
-    assert response.status_code == 422
+    assert response.status_code in (400, 422)
     assert 'shape' in response.text.lower()    #Check the response is sensible
 
 

--- a/compliance/test_error_response.py
+++ b/compliance/test_error_response.py
@@ -63,9 +63,9 @@ def test_nonexistent_file(monkeypatch):
     # Minio returns 404 but radosgw returs 500 so just check response code is something error-like
     assert response.status_code >= 400
     assert response.headers.get('content-type') == 'application/json'
-    # assert <something-about-informative-error-message-in-response-body?>
+    response.json()
+    assert "NoSuchKey" in response.text #Check for informative error message
 
-    
 
 def test_invalid_operation(monkeypatch):
 
@@ -80,6 +80,7 @@ def test_invalid_operation(monkeypatch):
     assert response.status_code in (404, 422)
     assert response.headers.get('content-type') == 'application/json'
     assert 'operation' in response.text.lower() #Check for informative error message
+    response.json()
     
 
 def test_invalid_dtype(monkeypatch):
@@ -95,7 +96,7 @@ def test_invalid_dtype(monkeypatch):
     assert response.status_code in (400, 422)
     assert response.headers.get('content-type') == 'application/json'
     assert 'dtype' in response.text.lower()
-
+    response.json()
 
 
 def test_invalid_offset(monkeypatch):
@@ -111,6 +112,7 @@ def test_invalid_offset(monkeypatch):
     assert response.status_code in (400, 422)
     assert response.headers.get('content-type') == 'application/json'
     assert 'offset' in response.text.lower()
+    response.json()
 
 
 def test_invalid_size(monkeypatch):
@@ -126,7 +128,7 @@ def test_invalid_size(monkeypatch):
     assert response.status_code in (400, 422)
     assert response.headers.get('content-type') == 'application/json'
     assert 'size' in response.text.lower()
-
+    response.json()
 
 
 def test_invalid_shape(monkeypatch):
@@ -142,7 +144,7 @@ def test_invalid_shape(monkeypatch):
     assert response.status_code in (400, 422)
     assert response.headers.get('content-type') == 'application/json'
     assert 'shape' in response.text.lower()    #Check the response is sensible
-
+    response.json()
 
 
 def test_invalid_selection(monkeypatch):
@@ -158,6 +160,7 @@ def test_invalid_selection(monkeypatch):
     assert response.status_code == 400
     assert response.headers.get('content-type') == 'application/json'
     assert 'selection' in response.text.lower()
+    response.json()
 
 
 def test_shape_without_selection(monkeypatch):
@@ -174,7 +177,7 @@ def test_shape_without_selection(monkeypatch):
     assert response.headers.get('content-type') == 'application/json'
     assert 'shape' in response.text.lower()
     assert 'selection' in response.text.lower()
-
+    response.json()
 
 
 def test_invalid_ordering(monkeypatch):
@@ -190,3 +193,4 @@ def test_invalid_ordering(monkeypatch):
     assert response.status_code == 400
     assert response.headers.get('content-type') == 'application/json'
     assert 'order' in response.text.lower()
+    response.json()

--- a/compliance/test_error_response.py
+++ b/compliance/test_error_response.py
@@ -93,6 +93,7 @@ def test_invalid_dtype(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code in (400, 422)
+    assert response.headers.get('content-type') == 'application/json'
     assert 'dtype' in response.text.lower()
 
 
@@ -108,6 +109,7 @@ def test_invalid_offset(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code in (400, 422)
+    assert response.headers.get('content-type') == 'application/json'
     assert 'offset' in response.text.lower()
 
 
@@ -122,6 +124,7 @@ def test_invalid_size(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code in (400, 422)
+    assert response.headers.get('content-type') == 'application/json'
     assert 'size' in response.text.lower()
 
 
@@ -137,6 +140,7 @@ def test_invalid_shape(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code in (400, 422)
+    assert response.headers.get('content-type') == 'application/json'
     assert 'shape' in response.text.lower()    #Check the response is sensible
 
 
@@ -152,6 +156,7 @@ def test_invalid_selection(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code == 400
+    assert response.headers.get('content-type') == 'application/json'
     assert 'selection' in response.text.lower()
 
 
@@ -166,6 +171,7 @@ def test_shape_without_selection(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code == 400
+    assert response.headers.get('content-type') == 'application/json'
     assert 'shape' in response.text.lower()
     assert 'selection' in response.text.lower()
 
@@ -182,4 +188,5 @@ def test_invalid_ordering(monkeypatch):
 
     #Check the response is sensible
     assert response.status_code == 400
+    assert response.headers.get('content-type') == 'application/json'
     assert 'order' in response.text.lower()


### PR DESCRIPTION
Python's FastAPI returns 422 in many cases, but Rust's Axum does not. Allow either code.

Use headers.get() to avoid a KeyError and get a proper assertion message.
