### PR TITLE
Modify size & offset semantics

### DIFF
--- a/compliance/utils.py
+++ b/compliance/utils.py
@@ -15,12 +15,11 @@ def ensure_test_bucket_exists():
         pass #Bucket already exists
 
 
-def upload_to_s3(s3_client, arr: np.array, filename: str) -> None:
+def upload_to_s3(s3_client, data: bytes, filename: str) -> None:
 
-    """ Upload a numpy array in binary format to an S3 storage bucket """
+    """ Upload a some binary data to an S3 storage bucket """
 
-    # NOTE: At this point it's a 1D array, so C/F order doesn't apply.
-    stream = io.BytesIO(arr.tobytes())
+    stream = io.BytesIO(data)
     s3_client.upload_fileobj(stream, BUCKET_NAME, filename)
 
     return


### PR DESCRIPTION
Previously in the size and offset tests, a numpy array of 100 elements was generated, and the size and offset applied to the binary formatted array data.
    
  0 -> offset: unused initial numpy array data
  offset -> offset + size: used numpy array data
  offset + size -> 100 * dtype_size: unused trailing numpy array data
    
This worked fine for raw data, but won't work for compressed or filtered data, since the entire compressed/filtered data stream must be read by the active storage server in order to decompress or reverse the
filtering.
    
This change modifies the semantics of size and offset to be more like the intended use case of netCDF data, in which chunks of (potentially compressed and/or filtered) data exist at different offsets in a file/object. We now always use the size/shape (with a default of 100 elements) to determine the size of the numpy array data, and offset this in the object with random bytes preceding it. A new trailing_bytes parameter also allows to add random bytes after the array data.
   
  0 -> offset: unused initial random bytes
  offset -> offset + size: numpy array data
  offset + size + trailing_bytes: unused trailing random bytes