### PR TITLE
Add compression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ pytest
 ```
 from within the project directory.
 
+### Testing older active storage servers
+
+We aim to add tests for features as they are added to the S3 active storage server.
+This does lead to problems when testing older versions of the server that may lack support for those features.
+This is addressed through configuration variables in `compliance/config.py`.
+
+- `TEST_X_ACTIVESTORAGE_COUNT_HEADER` - Whether to test for the presence of the `x-activestorage-count` header in responses.
+- `COMPRESSION_ALGS` - List of names of compression algorithms to test. May be set to an empty list.
+
 ### Implementation details
 
 Test data is currently generated as numpy arrays and then uploaded to the configured S3 source in binary format. Following this upload, requests are made to the active storage proxy and the proxy response is compared to the expected result based on the agreed API specification and the generated test arrays.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # S3 active storage compliance suite
 
-Unit tests and performance benchmarking tools for implementations of the s3-active-storage project.
-
-## Outline 
-
-The working plan for this repo is that, since we don't have an up-to-date reference implementation which conforms to the recently revised API spec, the default behaviour initially will be to mock responses from the active storage proxy. These mocks can be replaced by a URL pointing to a functional implementation of the proxy service at a later date.
+Integration tests and performance benchmarking tools for implementations of the s3-active-storage project.
 
 ## Compliance Suite Usage
 
@@ -16,7 +12,7 @@ source ./venv/bin/activate
 pip install -r requirements.txt
 ```
 
-To run the compliance test suite on your own implementation of an S3 active storage client, edit the following variables in `compliance/config.py`:
+To run the compliance test suite on your own implementation of an S3 active storage server, edit the following variables in `compliance/config.py`:
 
 - `S3_SOURCE` - The address of your S3 store (e.g. `https://s3-proxy.com/`). If you don't have an existing S3 store you can set up a temporary minio docker container by running `scripts/run-minio.sh` in a separate terminal, in which case you should leave the S3 source as localhost.
   

--- a/compliance/config.py
+++ b/compliance/config.py
@@ -31,4 +31,12 @@ OPERATION_FUNCS = {
     "mean": lambda arr: (np.sum(arr) / np.size(arr)).astype(arr.dtype),
 }
 
+# Whether to test for the presence of the x-activestorage-count header in responses.
 TEST_X_ACTIVESTORAGE_COUNT_HEADER = True
+
+# List of names of supported compression algorithms.
+# May be set to an empty list if compression is not supported by the server.
+COMPRESSION_ALGS = [
+    "gzip",
+    "zlib",
+]

--- a/compliance/test_basic_operations.py
+++ b/compliance/test_basic_operations.py
@@ -193,8 +193,10 @@ def test_basic_operation(
         "shape": shape,
         "order": order,
         "selection": selection,
-        "compression": compression,
     }
+
+    if compression:
+        request_data["compression"] = {"id": compression}
 
     # Mock proxy responses if url not set
     if PROXY_URL is None:

--- a/compliance/utils.py
+++ b/compliance/utils.py
@@ -1,8 +1,6 @@
 import gzip
 import io
-import pytest
 from botocore.exceptions import ClientError
-import numpy as np
 from typing import Optional
 import zlib
 from compliance.config import s3_client, BUCKET_NAME
@@ -11,7 +9,7 @@ from compliance.config import s3_client, BUCKET_NAME
 def ensure_test_bucket_exists():
     # Create required bucket if it doesn't yet exist
     try:
-        bucket = s3_client.create_bucket(Bucket=BUCKET_NAME)
+        s3_client.create_bucket(Bucket=BUCKET_NAME)
     except ClientError:
         pass  # Bucket already exists
 

--- a/compliance/utils.py
+++ b/compliance/utils.py
@@ -1,7 +1,10 @@
+import gzip
 import io
 import pytest
 from botocore.exceptions import ClientError
 import numpy as np
+from typing import Optional
+import zlib
 from compliance.config import s3_client, BUCKET_NAME
 
 
@@ -32,3 +35,14 @@ def fetch_from_s3(s3_client, filename: str) -> bytes:
         raise FileNotFoundError(
             f"File '{filename}' not found in S3 bucket '{BUCKET_NAME}'"
         )
+
+
+def filter_pipeline(data: bytes, compression: Optional[str]) -> bytes:
+    """Apply compression and filters to data and return the result."""
+    if compression == "gzip":
+        data = gzip.compress(data)
+    elif compression == "zlib":
+        data = zlib.compress(data)
+    elif compression is not None:
+        raise AssertionError(f"Unexpected compression algorithm {compression}")
+    return data


### PR DESCRIPTION
Adds a test_compression test which tests applying operations on
compressed data. Compression is applied only to the numeric data, with
any data before the offset or after the numeric data uncompressed random
bytes.

The list of compression algorithms to test is defined by
COMPRESSION_ALGS in config.py, which by default includes gzip and zlib.
For testing older versions of the active storage server,
COMPRESSION_ALGS may be set to an empty list.
