### PR TITLE
Add shuffle filter to compression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This is addressed through configuration variables in `compliance/config.py`.
 
 - `TEST_X_ACTIVESTORAGE_COUNT_HEADER` - Whether to test for the presence of the `x-activestorage-count` header in responses.
 - `COMPRESSION_ALGS` - List of names of compression algorithms to test. May be set to an empty list.
+- `FILTER_ALGS` - List of names of filter algorithms to test. May be set to an empty list.
 
 ### Implementation details
 

--- a/compliance/config.py
+++ b/compliance/config.py
@@ -40,3 +40,9 @@ COMPRESSION_ALGS = [
     "gzip",
     "zlib",
 ]
+
+# List of names of supported filter algorithms.
+# May be set to an empty list if filters are not supported by the server.
+FILTER_ALGS = [
+    "shuffle",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ idna==3.4
 iniconfig==1.1.1
 jmespath==1.0.1
 matplotlib==3.7.1
+numcodecs==0.11.0
 numpy==1.23.4
 packaging==21.3
 pluggy==1.0.0


### PR DESCRIPTION
Updates the test_compression test to support working with byte-shuffled
data.

The list of filter algorithms to test is defined by FILTER_ALGS in
config.py, which by default includes shuffle.

For testing older versions of the active storage server, FILTER_ALGS may
be set to an empty list.
