### PR TITLE
Add missing data tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is addressed through configuration variables in `compliance/config.py`.
 - `TEST_X_ACTIVESTORAGE_COUNT_HEADER` - Whether to test for the presence of the `x-activestorage-count` header in responses.
 - `COMPRESSION_ALGS` - List of names of compression algorithms to test. May be set to an empty list.
 - `FILTER_ALGS` - List of names of filter algorithms to test. May be set to an empty list.
+- `MISSING_DATA` - List of missing data description classes in `compliance/missing.py`. May be set to an empty list.
 
 ### Implementation details
 

--- a/compliance/config.py
+++ b/compliance/config.py
@@ -1,5 +1,8 @@
 import boto3
 import numpy as np
+import numpy.ma as ma
+
+from .missing import MissingValue, MissingValues, ValidMax, ValidMin, ValidRange
 
 # Location of upstream S3 data
 S3_SOURCE = "http://localhost:9000"
@@ -24,8 +27,8 @@ ALLOWED_DTYPES = ["int32", "int64", "float32", "float64", "uint32", "uint64"]
 
 OPERATION_FUNCS = {
     "select": lambda arr: arr,
-    "sum": lambda arr: np.sum(arr, dtype=arr.dtype),
-    "count": lambda arr: np.prod(arr.shape, dtype=np.int64),
+    "sum": lambda arr: ma.sum(arr, dtype=arr.dtype),
+    "count": lambda arr: np.array(ma.count(arr)),
     "max": np.max,
     "min": np.min,
 }
@@ -44,4 +47,14 @@ COMPRESSION_ALGS = [
 # May be set to an empty list if filters are not supported by the server.
 FILTER_ALGS = [
     "shuffle",
+]
+
+# List of missing data classes.
+# May be set to an empty list if missing data is not supported by the server.
+MISSING_DATA = [
+    MissingValue,
+    MissingValues,
+    ValidMax,
+    ValidMin,
+    ValidRange,
 ]

--- a/compliance/missing.py
+++ b/compliance/missing.py
@@ -1,0 +1,176 @@
+import abc
+from dataclasses import dataclass
+import numpy as np
+import numpy.ma as ma
+import numpy.typing as npt
+from typing import Dict, List, Union
+
+
+class Missing(abc.ABC):
+    """Base class for missing data descriptions."""
+
+    """Proportion of elements of the array that should be missing data."""
+    p_missing: float = 0.2
+
+    @classmethod
+    @abc.abstractmethod
+    def create(cls, dtype: np.dtype, operation: str):
+        """Create an instance of a subclass with appropriate values for the dtype.
+
+        The created object should affect the result of the operation for the
+        specified dtype.
+        """
+
+    @abc.abstractmethod
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        """Convert the missing data descriptor to the "missing" API request field."""
+
+    @abc.abstractmethod
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        """Apply a mask to an array that matches the missing data."""
+
+    @abc.abstractmethod
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        """Write missing data to random elements of an array."""
+
+
+def make_holes(
+    arr: npt.NDArray, p_missing: float, fill_values: List[Union[int, float]]
+) -> npt.NDArray:
+    """Write missing data to random elements of an array."""
+    rng = np.random.default_rng(10)
+    # For N fill values, write p_missing/N of each.
+    p_missing = p_missing / len(fill_values)
+    for fill_value in fill_values:
+        # Generate an array of random bools with the same shape as the data array.
+        mask = rng.choice([True, False], arr.shape, p=[p_missing, 1 - p_missing])
+        # Mask the data and fill with the fill value.
+        arr = ma.array(arr, mask=mask, fill_value=fill_value)
+        arr = ma.filled(arr)
+    return arr
+
+
+@dataclass
+class MissingValue(Missing):
+    """A single missing value."""
+
+    value: Union[int, float]
+
+    @classmethod
+    def create(cls, dtype: np.dtype, operation: str) -> Missing:
+        by_kind = {
+            "i": 999 if operation == "max" else -999,
+            "u": 0 if operation == "min" else 999,
+            "f": 1e20 if operation == "max" else -1e20,
+        }
+        return cls(by_kind[dtype.kind])
+
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        return {"missing_value": self.value}
+
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        return ma.masked_values(arr, self.value)
+
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        return make_holes(arr, self.p_missing, [self.value])
+
+
+@dataclass
+class MissingValues(Missing):
+    """A list of missing values."""
+
+    values: List[Union[int, float]]
+
+    @classmethod
+    def create(cls, dtype: np.dtype, operation: str) -> Missing:
+        by_kind: Dict[str, List[Union[int, float]]] = {
+            "i": [-999, 1000],
+            "u": [0, 999],
+            "f": [-1e20, 1e20],
+        }
+        return cls(by_kind[dtype.kind])
+
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        return {"missing_values": self.values}
+
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        return ma.masked_where(np.isin(arr, self.values), arr)
+
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        return make_holes(arr, self.p_missing, self.values)
+
+
+@dataclass
+class ValidMax(Missing):
+    """A valid maximum value."""
+
+    max: Union[int, float]
+
+    @classmethod
+    def create(cls, dtype: np.dtype, operation: str) -> Missing:
+        by_kind = {
+            "i": 8,
+            "u": 9,
+            "f": 10.0,
+        }
+        return cls(by_kind[dtype.kind])
+
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        return {"valid_max": self.max}
+
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        return ma.masked_greater(arr, self.max)
+
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        return make_holes(arr, self.p_missing, [self.max + 1])
+
+
+@dataclass
+class ValidMin(Missing):
+    """A valid minimum value."""
+
+    min: Union[int, float]
+
+    @classmethod
+    def create(cls, dtype: np.dtype, operation: str) -> Missing:
+        by_kind = {
+            "i": -1,
+            "u": 2,
+            "f": 0.5,
+        }
+        return cls(by_kind[dtype.kind])
+
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        return {"valid_min": self.min}
+
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        return ma.masked_less(arr, self.min)
+
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        return make_holes(arr, self.p_missing, [self.min - 1])
+
+
+@dataclass
+class ValidRange(Missing):
+    """A valid range of values."""
+
+    min: Union[int, float]
+    max: Union[int, float]
+
+    @classmethod
+    def create(cls, dtype: np.dtype, operation: str) -> Missing:
+        by_kind = {
+            "i": (2, 10),
+            "u": (1, 9),
+            "f": (0.5, 9.9),
+        }
+        return cls(*by_kind[dtype.kind])
+
+    def to_request_data(self) -> Dict[str, Union[int, float, List]]:
+        return {"valid_range": [self.min, self.max]}
+
+    def mask(self, arr: npt.NDArray) -> ma.MaskedArray:
+        return ma.masked_outside(arr, self.min, self.max)
+
+    def make_holes(self, arr: npt.NDArray) -> npt.NDArray:
+        return make_holes(arr, self.p_missing, [self.min - 1, self.max + 1])

--- a/compliance/mocks.py
+++ b/compliance/mocks.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.ma as ma
 
 
 class MockResponse:
@@ -16,7 +17,7 @@ class MockResponse:
             "content-length": str(len(self.content)),
             "x-activestorage-dtype": str(operation_result.dtype),
             "x-activestorage-shape": str(list(operation_result.shape)),
-            "x-activestorage-count": str(array_data.size),
+            "x-activestorage-count": str(ma.count(array_data)),
         }
         return
 

--- a/compliance/mocks.py
+++ b/compliance/mocks.py
@@ -1,26 +1,54 @@
+import json
 import numpy as np
 import numpy.ma as ma
+from typing import Dict
 
 
-class MockResponse:
-
+class BaseMockResponse(object):
     """Class used for mocking responses from the active storage proxy implementation in order to facilitate development of this test suite"""
 
     def __init__(
+        self,
+        status_code: int,
+        content: bytes,
+        headers: Dict[str, str],
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+
+    # Custom string representation for easier debugging
+    def __str__(self) -> str:
+        return f"\nMockResponse object:\n Status code: {self.status_code} \n Headers: {self.headers} \n Content: {self.content!r}"
+
+
+class MockResponse(BaseMockResponse):
+    def __init__(
         self, status_code: int, array_data: np.ndarray, operation_result, order="C"
     ) -> None:
-        # Template response attributes
-        self.status_code = status_code
-        self.content = operation_result.tobytes(order=order)
-        self.headers = {
+        content = operation_result.tobytes(order=order)
+        headers = {
             "content-type": "application/octet-stream",
             "content-length": str(len(self.content)),
             "x-activestorage-dtype": str(operation_result.dtype),
             "x-activestorage-shape": str(list(operation_result.shape)),
             "x-activestorage-count": str(ma.count(array_data)),
         }
-        return
+        super(MockResponse, self).__init__(status_code, content, headers)
 
-    # Custom string representation for easier debugging
-    def __str__(self) -> str:
-        return f"\nMockResponse object:\n Status code: {self.status_code} \n Headers: {self.headers} \n Content: {self.content}"
+
+class MockErrorResponse(BaseMockResponse):
+    def __init__(self, status_code: int) -> None:
+        content = json.dumps({"errors": []}).encode()
+        headers = {
+            "content-type": "application/json",
+            "content-length": str(len(self.content)),
+        }
+        super(MockErrorResponse, self).__init__(status_code, content, headers)
+
+
+class MockBadRequest(MockErrorResponse):
+    """400 Bad Request"""
+
+    def __init__(self):
+        super(MockBadRequest, self).__init__(400)


### PR DESCRIPTION
Add some tests covering missing data. There are 5 methods to define
missing data:

* a single missing value
* multiple missing values
* a valid minimum
* a valid maximum
* a valid range

Each of these is tested for each of the dtypes and operations, as well
as with and without a selection.

PR for reductionist missing data support: https://github.com/stackhpc/reductionist-rs/pull/62
